### PR TITLE
validate-tree: Ignore objects/services that are security-locked.

### DIFF
--- a/validate-tree/init.d.ts
+++ b/validate-tree/init.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="@rbxts/types" />
-declare type KeyExtendsPropertyName<T extends InstanceTree, K, V> = K extends "Changed" ? true : (T extends {
+declare type KeyExtendsPropertyName<T extends InstanceTree, K, V> = K extends "Changed" ? true : T extends {
     $className: keyof Instances;
-} ? (K extends keyof Instances[T["$className"]] ? unknown : V) : V);
+} ? K extends keyof Instances[T["$className"]] ? unknown : V : V;
 /** Defines a Rojo-esque tree type which defines an abstract object tree. */
 export interface InstanceTree {
     $className?: keyof Instances;
@@ -11,9 +11,9 @@ export interface InstanceTree {
 export declare type EvaluateInstanceTree<T extends InstanceTree, D = Instance> = (T extends {
     $className: keyof Instances;
 } ? Instances[T["$className"]] : D) & {
-    [K in Exclude<keyof T, "$className">]: KeyExtendsPropertyName<T, K, T[K] extends keyof Instances ? Instances[T[K]] : (T[K] extends {
+    [K in Exclude<keyof T, "$className">]: KeyExtendsPropertyName<T, K, T[K] extends keyof Instances ? Instances[T[K]] : T[K] extends {
         $className: keyof Instances;
-    } ? EvaluateInstanceTree<T[K]> : never)>;
+    } ? EvaluateInstanceTree<T[K]> : never>;
 };
 /** Returns whether a given Instance matches a particular Rojo-eque InstanceTree. */
 export declare function validateTree<I extends Instance, T extends InstanceTree>(object: I, tree: T, violators?: Array<string>): object is I & EvaluateInstanceTree<T, I>;

--- a/validate-tree/init.d.ts
+++ b/validate-tree/init.d.ts
@@ -16,7 +16,7 @@ export declare type EvaluateInstanceTree<T extends InstanceTree, D = Instance> =
     } ? EvaluateInstanceTree<T[K]> : never)>;
 };
 /** Returns whether a given Instance matches a particular Rojo-eque InstanceTree. */
-export declare function validateTree<I extends Instance, T extends InstanceTree>(object: I, tree: T): object is I & EvaluateInstanceTree<T, I>;
+export declare function validateTree<I extends Instance, T extends InstanceTree>(object: I, tree: T, violators?: Array<string>): object is I & EvaluateInstanceTree<T, I>;
 /** Yields until a given tree of objects exists within an object.
  * @param tree Must be an object tree similar to ones considered valid by Rojo.
  * Every tree must have a `$className` member, and can have any number of keys which represent

--- a/validate-tree/init.lua
+++ b/validate-tree/init.lua
@@ -1,5 +1,5 @@
 -- Compiled with https://roblox-ts.github.io v0.2.14
--- November 23, 2019, 1:36 PM Western European Standard Time
+-- November 23, 2019, 3:13 PM Western European Standard Time
 
 local TS = _G[script];
 local exports = {};
@@ -20,10 +20,10 @@ function validateTree(object, tree, violators)
 				end);
 				if not _2 then
 					local err = _3;
-					if tree["$className"] == "DataModel" then
+					if tree["$className"] == "DataModel" or object == game then
 						_continue_0 = true; break;
 					else
-						error("Could not validate the tree - Got '" .. tostring(err) .. "' in DataModel node");
+						error("Could not validate the tree - Got '" .. tostring(err) .. "' in non-DataModel node (child '" .. tostring(child) .. "')");
 					end;
 				end;
 				if childName ~= "$className" then

--- a/validate-tree/init.lua
+++ b/validate-tree/init.lua
@@ -1,5 +1,5 @@
 -- Compiled with https://roblox-ts.github.io v0.2.14
--- August 11, 2019, 4:44 AM Central Daylight Time
+-- November 23, 2019, 1:36 PM Western European Standard Time
 
 local TS = _G[script];
 local exports = {};
@@ -12,18 +12,36 @@ function validateTree(object, tree, violators)
 		local _0 = object:GetChildren();
 		for _1 = 1, #_0 do
 			local child = _0[_1];
-			local childName = child.Name;
-			if childName ~= "$className" then
-				local className = tree[childName];
-				local _2;
-				if (typeof(className) == "string") then
-					_2 = child:IsA(className);
-				else
-					_2 = className and validateTree(child, className, violators);
+			local _continue_0 = false;
+			repeat
+				local childName;
+				local _2, _3 = pcall(function()
+					childName = child.Name;
+				end);
+				if not _2 then
+					local err = _3;
+					if tree["$className"] == "DataModel" then
+						_continue_0 = true; break;
+					else
+						error("Could not validate the tree - Got '" .. tostring(err) .. "' in DataModel node");
+					end;
 				end;
-				if _2 then
-					whitelistedKeys[childName] = true;
+				if childName ~= "$className" then
+					local className = tree[childName];
+					local _4;
+					if (typeof(className) == "string") then
+						_4 = child:IsA(className);
+					else
+						_4 = className and validateTree(child, className, violators);
+					end;
+					if _4 then
+						whitelistedKeys[childName] = true;
+					end;
 				end;
+				_continue_0 = true;
+			until true;
+			if not _continue_0 then
+				break;
 			end;
 		end;
 		local matches = true;

--- a/validate-tree/package-lock.json
+++ b/validate-tree/package-lock.json
@@ -5,9 +5,9 @@
     "requires": true,
     "dependencies": {
         "@rbxts/types": {
-            "version": "1.0.235",
-            "resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.235.tgz",
-            "integrity": "sha512-6mHaM/el5/xHuzq1ECjXRuPq8iFsfO/7x7FoTdICD6b3ABUgvcOsNx+2txS2+MiE3QAGkMdybWS7RJ+slp9APQ=="
+            "version": "1.0.304",
+            "resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.304.tgz",
+            "integrity": "sha512-fwH6btAkxXKGoNmJiU1tuwWE39UW10bFKi6YDCSZSwetm4r9oUx6LuzhNHwrSjwcFYjve3A8dIZssLJbznlsew=="
         }
     }
 }

--- a/validate-tree/package.json
+++ b/validate-tree/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rbxts/validate-tree",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "Validates whether a given instance matches a given instance tree",
     "main": "init.lua",
     "types": "init.d.ts",
@@ -28,12 +28,12 @@
     },
     "homepage": "https://github.com/Validark/Roblox-TS-Libraries/blob/master/validate-tree/README.md",
     "peerDependencies": {
-        "@rbxts/types": "^1.0.227"
+        "@rbxts/types": "^1.0.304"
     },
     "publishConfig": {
         "access": "public"
     },
     "dependencies": {
-        "@rbxts/types": "^1.0.227"
+        "@rbxts/types": "^1.0.304"
     }
 }

--- a/validate-tree/src/init.ts
+++ b/validate-tree/src/init.ts
@@ -28,7 +28,7 @@ export declare type EvaluateInstanceTree<T extends InstanceTree, D = Instance> =
 				? Instances[T[K]]
 				: T[K] extends {
 						$className: keyof Instances;
-				  }
+				}
 				? EvaluateInstanceTree<T[K]>
 				: never
 		>;
@@ -44,18 +44,18 @@ export function validateTree<I extends Instance, T extends InstanceTree>(
 		const whitelistedKeys = new Set(["$className"]);
 
 		for (const child of object.GetChildren()) {
-			/* Possible Roblox security context violation if tree root is the DataModel */
+			/* Possible Roblox security context violation if tree root is the DataModel (aka 'game') */
 
 			let childName;
 			try {
 				childName = child.Name;
 			} catch (err) {
 				/* Expected situation: The current identity (X) cannot Class security check (lacking permission Y) */
-				if (tree.$className === "DataModel") {
+				if (tree.$className === "DataModel" || object as Instance === game) {
 					continue;
 				} else {
 					// FIXME Proper runtime error message
-					throw "Could not validate the tree - Got '" + err + "' in DataModel node";
+					throw "Could not validate the tree - Got '" + err + "' in non-DataModel node (child '" + child + "')";
 				}
 			}
 


### PR DESCRIPTION
Attempts to fix #2. In practice, all it does is wrapping child indexing in a `try-catch` statement and ignore the child if it errors and if the root of the tree is `game` - otherwise, the error will be rethrown.

## Other details:
- I have only done a minimal set of tests to it and it does seem to work. However, it might be a good idea to perform more extensive testing, in particular to make sure no false positives are thrown.
- Version bump to `1.0.5`
- I have ran `prettier` on the script (again), and it seemed to have removed a couple parenthesis from the type definitions.