### PR TITLE
Remove comments from tsconfig.json

### DIFF
--- a/signal/tsconfig.json
+++ b/signal/tsconfig.json
@@ -1,6 +1,5 @@
 {
 	"compilerOptions": {
-		// required
 		"allowSyntheticDefaultImports": true,
 		"downlevelIteration": true,
 		"module": "commonjs",
@@ -10,13 +9,10 @@
 		"typeRoots": [
 			"node_modules/@rbxts"
 		],
-		// required, configurable
 		"rootDir": "src",
 		"outDir": "out",
-		// optional
 		"baseUrl": "src",
 		"declaration": true,
-		// optional, non-configurable
 		"jsx": "react",
 		"jsxFactory": "Roact.createElement"
 	},


### PR DESCRIPTION
Rojo 6 syncs *.json files as ModuleScripts, but since comments are not part of the JSON specification this causes Rojo to terminate as it does not handle comments within JSON files.