### PR TITLE
only return spawn from delay-spawn-wait

### DIFF
--- a/fast-spawn/init.lua
+++ b/fast-spawn/init.lua
@@ -1,1 +1,1 @@
-return require(assert(script.Parent:FindFirstChild("delay-spawn-wait"), "[@rbxts/easing-functions] Please `npm install @rbxts/delay-spawn-wait` to use this library."))
+return require(assert(script.Parent:FindFirstChild("delay-spawn-wait"), "[@rbxts/easing-functions] Please `npm install @rbxts/delay-spawn-wait` to use this library.")).spawn


### PR DESCRIPTION
The fast-spawn package depends upon delay-spawn-wait for it to function, which returns a table consisting of the spawn, wait, and delay functions

The fast-spawn module was directly returning the table that delay-spawn-wait returns, when it should only be returning the spawn function
