### PR TITLE
Update signal library typings

### DIFF
--- a/signal/index.d.ts
+++ b/signal/index.d.ts
@@ -1,20 +1,20 @@
 /**
  * BindableEvent wrapper which passes variables by reference instead of by value
  */
-interface Signal<ConnectedFunctionSignature = () => void, Generic = false> {
+interface Signal<ConnectedFunctionSignature extends () => void, Generic = false> {
 	/**
 	 * Fires the BindableEvent with any number of arguments
 	 * @param args The arguments to pass into the connected functions
 	 */
-	Fire(...args: FunctionArguments<ConnectedFunctionSignature>): void;
+	Fire(...args: Parameters<ConnectedFunctionSignature>): void;
 
 	/**
 	 * Connects a callback to BindableEvent.Event
 	 * @param callback The function to connect to BindableEvent.Event
 	 */
-	Connect<O extends Array<unknown> = FunctionArguments<ConnectedFunctionSignature>>(
+	Connect<O extends Array<unknown> = Parameters<ConnectedFunctionSignature>>(
 		callback: Generic extends true
-			? (FunctionArguments<ConnectedFunctionSignature> extends Array<unknown>
+			? (Parameters<ConnectedFunctionSignature> extends Array<unknown>
 					? (...args: O) => void
 					: ConnectedFunctionSignature)
 			: ConnectedFunctionSignature,
@@ -23,7 +23,7 @@ interface Signal<ConnectedFunctionSignature = () => void, Generic = false> {
 	/**
 	 * Yields the current thread until the thread is fired.
 	 */
-	Wait(): LuaTuple<FunctionArguments<ConnectedFunctionSignature>>;
+	Wait(): LuaTuple<Parameters<ConnectedFunctionSignature>>;
 
 	/**
 	 * Destroys the Signal
@@ -31,7 +31,7 @@ interface Signal<ConnectedFunctionSignature = () => void, Generic = false> {
 	Destroy(): void;
 }
 
-declare const Signal: new <ConnectedFunctionSignature = () => void, Generic = false>() => Signal<
+declare const Signal: new <ConnectedFunctionSignature extends () => void, Generic = false>() => Signal<
 	ConnectedFunctionSignature,
 	Generic
 >;

--- a/signal/index.d.ts
+++ b/signal/index.d.ts
@@ -1,7 +1,7 @@
 /**
  * BindableEvent wrapper which passes variables by reference instead of by value
  */
-interface Signal<ConnectedFunctionSignature extends () => void, Generic = false> {
+interface Signal<ConnectedFunctionSignature extends Callback, Generic = false> {
 	/**
 	 * Fires the BindableEvent with any number of arguments
 	 * @param args The arguments to pass into the connected functions
@@ -31,7 +31,7 @@ interface Signal<ConnectedFunctionSignature extends () => void, Generic = false>
 	Destroy(): void;
 }
 
-declare const Signal: new <ConnectedFunctionSignature extends () => void, Generic = false>() => Signal<
+declare const Signal: new <ConnectedFunctionSignature extends Callback, Generic = false>() => Signal<
 	ConnectedFunctionSignature,
 	Generic
 >;

--- a/signal/package-lock.json
+++ b/signal/package-lock.json
@@ -1,13 +1,20 @@
 {
-    "name": "rbx-signal",
+    "name": "@rbxts/signal",
     "version": "1.0.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@rbxts/compiler-types": {
+            "version": "1.0.0-beta.14.0",
+            "resolved": "https://registry.npmjs.org/@rbxts/compiler-types/-/compiler-types-1.0.0-beta.14.0.tgz",
+            "integrity": "sha512-+HED2+jmya7Lilgd0WkvFymzntqrKIY676O8mohdhwuKxn4jziwqiWPl3DnSRdyTeTvriQ/FO76OrtfWyboqUw==",
+            "dev": true
+        },
         "@rbxts/types": {
-            "version": "1.0.194",
-            "resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.194.tgz",
-            "integrity": "sha512-r+ROYdFeI0rY6/7T9I+gKrorOuqsLPozsFhM8lrN4RJGF9zL6NWbvRcp/TgSu/Y3BWFGhOOUrtu3ppQR5TzdgA=="
+            "version": "1.0.438",
+            "resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.438.tgz",
+            "integrity": "sha512-Z8ag+HxFXHJ1Jx4YKmQfq4RPZoOa/dzaLRJZsZHiknuP/rxF0NISWDogx5HbQPq9ocY5OUipbLEIB6qGPkqohQ==",
+            "dev": true
         }
     }
 }

--- a/signal/package.json
+++ b/signal/package.json
@@ -24,9 +24,6 @@
         "url": "https://github.com/Validark/Roblox-TS-Libraries/issues"
     },
     "homepage": "https://github.com/Validark/Roblox-TS-Libraries/blob/master/signal/README.md",
-    "peerDependencies": {
-        "@rbxts/types": "^1.0.194"
-    },
     "publishConfig": {
         "access": "public"
     },
@@ -34,5 +31,10 @@
         "init.lua",
         "index.d.ts",
         "README.md"
-    ]
+    ],
+    "dependencies": {},
+    "devDependencies": {
+        "@rbxts/compiler-types": "^1.0.0-beta.14.0",
+        "@rbxts/types": "^1.0.438"
+    }
 }


### PR DESCRIPTION
The signal library's typings have been broken with recent changes the utility types in roblox-ts. This uses the new `Parameters` utility type instead of the now gone `FunctionArguments`