### PR TITLE
Change `Part` to `BasePart` in yield-for-character

### DIFF
--- a/yield-for-character/src/init.ts
+++ b/yield-for-character/src/init.ts
@@ -4,7 +4,7 @@ export const CharacterRigR6 = {
 	$className: "Model",
 
 	Head: {
-		$className: "Part",
+		$className: "BasePart",
 		FaceCenterAttachment: "Attachment",
 		FaceFrontAttachment: "Attachment",
 		HairAttachment: "Attachment",
@@ -14,7 +14,7 @@ export const CharacterRigR6 = {
 	},
 
 	HumanoidRootPart: {
-		$className: "Part",
+		$className: "BasePart",
 		RootAttachment: "Attachment",
 		RootJoint: "Motor6D",
 	},
@@ -26,29 +26,29 @@ export const CharacterRigR6 = {
 	},
 
 	["Left Arm"]: {
-		$className: "Part",
+		$className: "BasePart",
 		LeftGripAttachment: "Attachment",
 		LeftShoulderAttachment: "Attachment",
 	},
 
 	["Left Leg"]: {
-		$className: "Part",
+		$className: "BasePart",
 		LeftFootAttachment: "Attachment",
 	},
 
 	["Right Arm"]: {
-		$className: "Part",
+		$className: "BasePart",
 		RightGripAttachment: "Attachment",
 		RightShoulderAttachment: "Attachment",
 	},
 
 	["Right Leg"]: {
-		$className: "Part",
+		$className: "BasePart",
 		RightFootAttachment: "Attachment",
 	},
 
 	Torso: {
-		$className: "Part",
+		$className: "BasePart",
 		["Left Hip"]: "Motor6D",
 		["Left Shoulder"]: "Motor6D",
 		["Right Hip"]: "Motor6D",
@@ -75,7 +75,7 @@ export const CharacterRigR15 = {
 	$className: "Model",
 
 	HumanoidRootPart: {
-		$className: "Part",
+		$className: "BasePart",
 		RootRigAttachment: { $className: "Attachment", OriginalPosition: "Vector3Value" },
 		OriginalSize: "Vector3Value",
 	},
@@ -217,8 +217,7 @@ export const CharacterRigR15 = {
 	},
 
 	Head: {
-		$className: "Part",
-		Mesh: { $className: "SpecialMesh", OriginalSize: "Vector3Value" },
+		$className: "BasePart",
 		FaceCenterAttachment: { $className: "Attachment", OriginalPosition: "Vector3Value" },
 		FaceFrontAttachment: { $className: "Attachment", OriginalPosition: "Vector3Value" },
 		HairAttachment: { $className: "Attachment", OriginalPosition: "Vector3Value" },


### PR DESCRIPTION
Required for https://devforum.roblox.com/t/action-required-meshpart-heads-accessories-may-27th/1170183
Not "MeshPart" because that would break when people use the disable override.